### PR TITLE
Fix/refactor endpoints

### DIFF
--- a/src/ApiDiscussionsResults.js
+++ b/src/ApiDiscussionsResults.js
@@ -14,6 +14,7 @@ const discussionFiles = [
   "discussions-ufs-community-ufs-da-workflow.json",
 ];
 
+// Prepend the bucket to the path 
 const discussionEndpoints = discussionFiles.map(
   file => `${config.discussionsBucket}/${file}`
 );

--- a/src/ApiDiscussionsResults.js
+++ b/src/ApiDiscussionsResults.js
@@ -4,18 +4,18 @@ import "./App.css";
 import config from "./config";
 
 const discussionFiles = [
-  "hafs-community-HAFS.json",
-  "NOAA-EMC-UPP.json",
-  "NOAA-EPIC-land-offline_workflow.json",
-  "NOAA-EPIC-EAGLE.json",
-  "ufs-community-land-DA_workflow.json",
-  "ufs-community-ufs-srweather-app.json",
-  "ufs-community-ufs-weather-model.json",
-  "ufs-community-ufs-da-workflow.json",
+  "discussions-hafs-community-HAFS.json",
+  "discussions-NOAA-EMC-UPP.json",
+  "discussions-NOAA-EPIC-land-offline_workflow.json",
+  "discussions-NOAA-EPIC-EAGLE.json",
+  "discussions-ufs-community-land-DA_workflow.json",
+  "discussions-ufs-community-ufs-srweather-app.json",
+  "discussions-ufs-community-ufs-weather-model.json",
+  "discussions-ufs-community-ufs-da-workflow.json",
 ];
 
 const discussionEndpoints = discussionFiles.map(
-  file => `${config.discussionsBucket}/discussions-${file}`
+  file => `${config.discussionsBucket}/${file}`
 );
 
 function ApiDiscussionResults() {

--- a/src/ApiDiscussionsResults.js
+++ b/src/ApiDiscussionsResults.js
@@ -3,16 +3,20 @@ import ItemDataGrid from "./ItemDataGrid";
 import "./App.css";
 import config from "./config";
 
-const discussionEndpoints = [
-  `${config.discussionsBucket}/discussions-hafs-community-HAFS.json`,
-  `${config.discussionsBucket}/discussions-NOAA-EMC-UPP.json`,
-  `${config.discussionsBucket}/discussions-NOAA-EPIC-land-offline_workflow.json`,
-  `${config.discussionsBucket}/discussions-NOAA-EPIC-EAGLE.json`,  
-  `${config.discussionsBucket}/discussions-ufs-community-land-DA_workflow.json`,
-  `${config.discussionsBucket}/discussions-ufs-community-ufs-srweather-app.json`,
-  `${config.discussionsBucket}/discussions-ufs-community-ufs-weather-model.json`,
-  `${config.discussionsBucket}/discussions-ufs-community-ufs-da-workflow.json`,  
+const discussionFiles = [
+  "hafs-community-HAFS.json",
+  "NOAA-EMC-UPP.json",
+  "NOAA-EPIC-land-offline_workflow.json",
+  "NOAA-EPIC-EAGLE.json",
+  "ufs-community-land-DA_workflow.json",
+  "ufs-community-ufs-srweather-app.json",
+  "ufs-community-ufs-weather-model.json",
+  "ufs-community-ufs-da-workflow.json",
 ];
+
+const discussionEndpoints = discussionFiles.map(
+  file => `${config.discussionsBucket}/discussions-${file}`
+);
 
 function ApiDiscussionResults() {
   return (

--- a/src/ApiIssuesResults.js
+++ b/src/ApiIssuesResults.js
@@ -3,16 +3,20 @@ import IssueDataGrid from "./IssueDataGrid";
 import "./App.css";
 import config from "./config";
 
-const issueEndpoints = [
-  `${config.issuesBucket}/issues-hafs-community-HAFS.json`,
-  `${config.issuesBucket}/issues-NOAA-EMC-UPP.json`,
-  `${config.issuesBucket}/issues-NOAA-EPIC-land-offline_workflow.json`,
-  `${config.issuesBucket}/issues-NOAA-EPIC-EAGLE.json`,  
-  `${config.issuesBucket}/issues-ufs-community-land-DA_workflow.json`,
-  `${config.issuesBucket}/issues-ufs-community-ufs-srweather-app.json`,
-  `${config.issuesBucket}/issues-ufs-community-ufs-weather-model.json`,
-  `${config.issuesBucket}/issues-ufs-community-ufs-da-workflow.json`,  
+const issueFiles = [
+  "hafs-community-HAFS.json",
+  "NOAA-EMC-UPP.json",
+  "NOAA-EPIC-land-offline_workflow.json",
+  "NOAA-EPIC-EAGLE.json",
+  "ufs-community-land-DA_workflow.json",
+  "ufs-community-ufs-srweather-app.json",
+  "ufs-community-ufs-weather-model.json",
+  "ufs-community-ufs-da-workflow.json",
 ];
+
+const issueEndpoints = issueFiles.map(
+  file => `${config.issuesBucket}/issues-${file}`
+);
 
 function ApiIssuesResults() {
   return (

--- a/src/ApiIssuesResults.js
+++ b/src/ApiIssuesResults.js
@@ -14,6 +14,7 @@ const issueFiles = [
   "issues-ufs-community-ufs-da-workflow.json",
 ];
 
+// Prepend the bucket to the path
 const issueEndpoints = issueFiles.map(
   file => `${config.issuesBucket}/${file}`
 );

--- a/src/ApiIssuesResults.js
+++ b/src/ApiIssuesResults.js
@@ -4,18 +4,18 @@ import "./App.css";
 import config from "./config";
 
 const issueFiles = [
-  "hafs-community-HAFS.json",
-  "NOAA-EMC-UPP.json",
-  "NOAA-EPIC-land-offline_workflow.json",
-  "NOAA-EPIC-EAGLE.json",
-  "ufs-community-land-DA_workflow.json",
-  "ufs-community-ufs-srweather-app.json",
-  "ufs-community-ufs-weather-model.json",
-  "ufs-community-ufs-da-workflow.json",
+  "issues-hafs-community-HAFS.json",
+  "issues-NOAA-EMC-UPP.json",
+  "issues-NOAA-EPIC-land-offline_workflow.json",
+  "issues-NOAA-EPIC-EAGLE.json",
+  "issues-ufs-community-land-DA_workflow.json",
+  "issues-ufs-community-ufs-srweather-app.json",
+  "issues-ufs-community-ufs-weather-model.json",
+  "issues-ufs-community-ufs-da-workflow.json",
 ];
 
 const issueEndpoints = issueFiles.map(
-  file => `${config.issuesBucket}/issues-${file}`
+  file => `${config.issuesBucket}/${file}`
 );
 
 function ApiIssuesResults() {

--- a/src/CICDDashboard.js
+++ b/src/CICDDashboard.js
@@ -9,6 +9,7 @@ const artifactDataFiles = [
   "land-DA_workflow-dashboard.json",
 ];
 
+// Prepend the bucket to the path
 const artifactDataEndpoints = artifactDataFiles.map(
   file => `${config.reactBucket}/${file}`
 );

--- a/src/CICDDashboard.js
+++ b/src/CICDDashboard.js
@@ -3,11 +3,15 @@ import ArtifactDataGrid from "./ArtifactDataGrid";
 import "./App.css";
 import config from "./config";
 
-const artifact_data_endpoints = [
-  `${config.reactBucket}/ufs-srweather-app-dashboard.json`,
-  `${config.reactBucket}/ufs-weather-model-dashboard.json`, 
-  `${config.reactBucket}/land-DA_workflow-dashboard.json`,
+const artifactDataFiles = [
+  "ufs-srweather-app-dashboard.json",
+  "ufs-weather-model-dashboard.json",
+  "land-DA_workflow-dashboard.json",
 ];
+
+const artifactDataEndpoints = artifactDataFiles.map(
+  file => `${config.reactBucket}/${file}`
+);
 
 function removeDashboard(title) {
   return title.replace(/-dashboard.*$/i, "").trim();
@@ -25,7 +29,7 @@ function CICDpiepline() {
       return projectName;
     };
 
-    const titles = artifact_data_endpoints.map((endpoint) =>
+    const titles = artifactDataEndpoints.map((endpoint) =>
       removeDashboard(extractProjectName(endpoint))
     );
     setTableTitles(titles);
@@ -33,7 +37,7 @@ function CICDpiepline() {
 
   return (
     <div style={{ padding: 30 }}>
-      {artifact_data_endpoints.map((endpoint, index) => (
+      {artifactDataEndpoints.map((endpoint, index) => (
         <div key={index} style={{ marginBottom: 130 }}>
           <h1>{tableTitles[index]} CI/CD Artifacts</h1>
           <ArtifactDataGrid endpoints={[endpoint]} />

--- a/src/config.js
+++ b/src/config.js
@@ -1,12 +1,21 @@
 const hostname = window.location.hostname;
 
-const isDev =
+let isDev =
   hostname === 'localhost' ||
   hostname === '127.0.0.1' ||
   hostname.includes('-dev');
 
+//*****************************************************************************
+// You can uncomment the line below to test code locally using prod buckets
+// rather than dev buckets. This can be useful to make sure the prod buckets
+// don't have any permission or path issues. 
+
+// IMPORTANT: Re-comment this line before deploying.
+
+//isDev = false;
+//*****************************************************************************
+
 const env = isDev ? 'dev' : 'prod';
-//const env = 'prod';
 
 const discussionsBucket = `https://epic-health-dashboard-artifacts-${env}.s3.us-east-1.amazonaws.com`;
 const jenkinsBucket = `https://noaa-epic-${env}-jenkins-artifacts.s3.amazonaws.com`;


### PR DESCRIPTION
Minor refactor to eliminate unnecessary repetition of bucket names. Also added an easy way to toggle between dev and prod buckets when testing locally to ensure there are no issues pulling data from prod before deploying.